### PR TITLE
Include miasma dir in bundle archive

### DIFF
--- a/scripts/build.rb
+++ b/scripts/build.rb
@@ -7,6 +7,6 @@ bundle_files = Dir[ 'bin/*', 'commands/*' ] + %w(manifest.json config.yaml)
 # Create .cog
 Zip::File.open("miasma.cog", Zip::File::CREATE) do |z|
   bundle_files.each do |f|
-    z.add(f, f)
+    z.add("miasma/#{f}", f)
   end
 end


### PR DESCRIPTION
During install, Cog looks in a directory with the same name as the
bundle for the config and all other files.

@luckymike This should fix your install issues.

I also created an issue in Cog to print a more descriptive error message: https://github.com/operable/cog/issues/455
